### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/buglloc/sly64/security/code-scanning/1](https://github.com/buglloc/sly64/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/release.yml` so the workflow does not inherit potentially over-privileged defaults.  
Best fix without changing behavior: define minimal required permissions at workflow root and allow only what release needs.

For this workflow:
- `contents: write` is typically required for creating/updating GitHub Releases and release assets.
- `packages: write` may be needed if artifacts are published to GitHub Packages/GHCR.
- Keep everything else implicitly `none`.

Edit region:
- Insert `permissions:` after the `on:` trigger block (before `jobs:`), so it applies to all jobs unless overridden.

No imports, methods, or extra definitions are needed (YAML config change only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
